### PR TITLE
Support captive portal popup for windows 10

### DIFF
--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -9,5 +9,6 @@ address=/www.gstatic.com/216.58.206.99
 address=/www.apple.com/2.16.21.112
 address=/captive.apple.com/17.253.35.204
 address=/clients3.google.com/216.58.204.46
+address=/www.msftconnecttest.com/13.107.4.52
 #Below is for the future implemantation of rfc 7710
 dhcp-option=160,http://hotspot.localnet/index.php


### PR DESCRIPTION
When connecting to Raspberry pi + Captive-Portal with a Windows 10 machine, there was no "popup" in the browser. 
Adding the www.msftconnecttest.com address to dnsmasq has solved the problem. 

Steps to discover: 
- enable "log-queries" and set "log-facility" in dnsmasq.conf
- try to connect windows 10 to raspi
- see the dns query attemps in dnsmasq.log:
Dec 12 04:55:27 dnsmasq[521]: query[A] www.msftconnecttest.com from 192.168.24.40

Once that entry has been added to dnsmasq.conf, the dns query returns successfully. 
Checking the nginx logs, you'll then see:
"GET /connecttest.txt HTTP/1.1" 302 161 "-" "Microsoft NCSI"
"GET /connecttest.txt HTTP/1.1" 302 161 "-" "Microsoft NCSI"
followed by the redirect request from the browser 
"GET /redirect HTTP/1.1" 302
this is then successfully redirected to http://hotspot.localnet/index.php